### PR TITLE
Pass npm exit code through to the calling shell

### DIFF
--- a/bin/npm-install-retry
+++ b/bin/npm-install-retry
@@ -6,13 +6,15 @@ var run     = require('../');
 var npmargs   = process.argv.indexOf('--') === -1 ? '' : process.argv.slice(process.argv.indexOf('--')+1);
 var retryargs = process.argv.indexOf('--') === -1 ? process.argv : process.argv.slice(0, process.argv.indexOf('--'));
 
+// Prepend install command
+npmargs = ['install'].concat(npmargs);
+
 program
   .version(require(__dirname + '/../package.json').version)
   .option('-a, --attempts [10]', 'Number of attempts before fail [10]', 10)
   .option('-w, --wait [500]', 'Milliseconds to wait between tries [10]', 10)
   .parse(retryargs);
 
-run('npm install', npmargs, {wait: program.wait, attempts: program.attempts}, function (err) {
-  if (err) return process.exit(1);
-  process.exit(0);
+run('npm', npmargs, {wait: program.wait, attempts: program.attempts}, function (err, data) {
+  process.exit((data && data.hasOwnProperty('exitCode')) ? data.exitCode : 1);
 });

--- a/index.js
+++ b/index.js
@@ -1,15 +1,33 @@
 require('colors');
-var exec    = require('child_process').exec;
+var spawn    = require('child_process').spawn;
 
 module.exports = function (command, args, options, callback) {
   var times = 1;
   function run () {
-    var runCmd = command + ' ' + args;
+    var runCmd = command + ' ' + args.join(' ');
     console.log(('attempt ' + times).bold.green + ': ' + runCmd);
 
     process.env.npm_config_color = 0;
 
-    var attempt = exec(runCmd, function (err, stdout, stderr) {
+    var attempt = spawn(command, args);
+    var stdout = [], stderr = [];
+
+    attempt.stdout.on('data', function (data) {
+      stdout.push(data);
+    });
+
+    attempt.stderr.on('data', function(data) {
+      stderr.push(data);
+    });
+
+    attempt.on('error', function(err) {
+      return callback(err);
+    });
+
+    attempt.on('close', function (exitCode) {
+      stdout = Buffer.concat(stdout).toString();
+      stderr = Buffer.concat(stderr).toString();
+
       if (stdout.match(/npm ERR\! cb\(\) never called\!/ig) || stderr.match(/npm ERR\! cb\(\) never called\!/ig)) {
         if (times >= options.attempts) {
           return callback(new Error('too many attempts'));
@@ -17,9 +35,10 @@ module.exports = function (command, args, options, callback) {
         times++;
         return setTimeout(run, options.wait);
       }
-      return callback(null, {times: times, stdout: stdout});
+
+      return callback(null, {times: times, stdout: stdout, exitCode: exitCode});
     });
-    
+
     attempt.stdout.pipe(process.stdout);
     attempt.stderr.pipe(process.stderr);
   }


### PR DESCRIPTION
Hello!

I started using your utility for my Jenkins builds and noticed a problem with it. It doesn't pass the exit code of the npm command through to the calling shell. So for example a `npm-install-retry -- thispackagedoesnotexist` still returns exit code 0, which doesn't stop the Jenkins build (even though the npm install failed).
For this reason I created this PR, which tbh introduces a lot of changes, though I tried to stay as close to the original code as possible. If it changes too much, it may still be an inspiation for your own implemenation :smile:

Regards,
Benni
