### PR TITLE
fix: support for multiple npm args

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var exec    = require('child_process').exec;
 module.exports = function (command, args, options, callback) {
   var times = 1;
   function run () {
-    var runCmd = command + ' ' + args;
+    var runCmd = command + ' ' + args.join(' ');
     console.log(('attempt ' + times).bold.green + ': ' + runCmd);
 
     process.env.npm_config_color = 0;


### PR DESCRIPTION
This fixes support for using multiple npm arguments. Previously they were incorrectly concatened with a comma instead of a space.

## before

```bash
❯ npm-install-retry -- --production
attempt 1: npm install --production
...
```

```bash
❯ npm-install-retry -- --production --verbose
attempt 1: npm install --production,--verbose
...
```

## after

```bash
❯ npm-install-retry -- --production
attempt 1: npm install --production
...
```

```bash
❯ npm-install-retry -- --production --verbose
attempt 1: npm install --production --verbose
...
```