### PR TITLE
Feature: Read matchers from config file

### DIFF
--- a/.npmretry.json
+++ b/.npmretry.json
@@ -1,0 +1,4 @@
+{
+  "matchers": ["npm ERR\\! cb\\(\\) never called\\!", "npm ERR\\! errno ECONNRESET",
+               "npm ERR\\! shasum check failed", "npm ERR\\! code EINTEGRITY"]
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Build status](https://ci.appveyor.com/api/projects/status/sc7937we6gb0mwoc?svg=true)
 
-Command line utility that retries  `npm install` when NPM fails with flaky errors: 
+Command line utility that retries  `npm install` when NPM fails with flaky errors:
 * `npm ERR! cb() never called`,
 * `npm ERR! errno ECONNRESET`,
 * `npm ERR! shasum check failed`,
@@ -27,9 +27,25 @@ and still fails.
 
 From command-line:
 
-	npm-install-retry --wait 500 --attempts 10 -- --production
+	npm-install-retry --wait 500 --attempts 10 --configFile config.json -- --production
 
-It has two options wait (defaults to 500) and attempts (default to 10). Everything after `--` goes directly to npm.
+It has the following options: `wait` (defaults to 500), `attempts` (default to 10), and `configFile`. Everything after `--` goes directly to npm.
+
+#### Config file
+
+The config JSON file is currently only used to provide a list of regex strings that should match an NPM error and trigger a retry. For example:
+
+```
+{
+  "matchers": ["npm ERR\\! cb\\(\\) never called\\!", "npm ERR\\! errno ECONNRESET",
+               "npm ERR\\! shasum check failed", "npm ERR\\! code EINTEGRITY"]
+}
+```
+
+The config file is chosen in the following order:
+1) A user-specified file (using `--configFile`)
+2) `.npmretry.json` in the user's home directory
+3) `.npmretry.json` in the `npm-install-retry` installation directory
 
 ## License
 

--- a/bin/npm-install-retry
+++ b/bin/npm-install-retry
@@ -10,9 +10,10 @@ program
   .version(require(__dirname + '/../package.json').version)
   .option('-a, --attempts [10]', 'Number of attempts before fail [10]', 10)
   .option('-w, --wait [500]', 'Milliseconds to wait between tries [10]', 10)
+  .option('-c, --configFile <path>', 'Custom config JSON for npm-install-retry.')
   .parse(retryargs);
 
-run('npm install', npmargs, {wait: program.wait, attempts: program.attempts}, function (err, res) {
+run('npm install', npmargs, {wait: program.wait, attempts: program.attempts, configFile: program.configFile}, function (err, res) {
   if (err) return process.exit(1);
   process.exit(res.exitCode);
 });

--- a/bin/npm-install-retry
+++ b/bin/npm-install-retry
@@ -10,7 +10,7 @@ program
   .version(require(__dirname + '/../package.json').version)
   .option('-a, --attempts [10]', 'Number of attempts before fail [10]', 10)
   .option('-w, --wait [500]', 'Milliseconds to wait between tries [10]', 10)
-  .option('-c, --configFile <path>', 'Custom config JSON for npm-install-retry.')
+  .option('-c, --configFile <path>', 'Custom config JSON for npm-install-retry')
   .parse(retryargs);
 
 run('npm install', npmargs, {wait: program.wait, attempts: program.attempts, configFile: program.configFile}, function (err, res) {


### PR DESCRIPTION
Adds support for loading a custom config file that contains the matchers to be used in spotting certain NPM errors and triggering retries.

The goal is to make it simple for users to customize which NPM errors they need to match on without changing functionality of existing syntax.

By default, the same current list of supported matchers is loaded from `.npmretry.json`:

```
{
  "matchers": ["npm ERR\\! cb\\(\\) never called\\!", "npm ERR\\! errno ECONNRESET",
               "npm ERR\\! shasum check failed", "npm ERR\\! code EINTEGRITY"]
}
```

Users can also create a `~/.npmretry.json` or specify a path to a file with `--configFile`